### PR TITLE
chore: bump GitHub runner image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM myoung34/github-runner:2.318.0-ubuntu-focal
+FROM myoung34/github-runner:2.319.1-ubuntu-focal
 
 # modify actions runner binaries to allow custom cache server implementation
 # https://gha-cache-server.falcondev.io/getting-started


### PR DESCRIPTION
Fix this error in runner startup:

> An error occured: Runner version v2.318.0 is deprecated and cannot receive messages.

[Slack conversation](https://walletconnect.slack.com/archives/C068RRL89HC/p1726599122644059?thread_ts=1726575163.855779&cid=C068RRL89HC)