### PR TITLE
fix: updating the runner image to v2.327.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM myoung34/github-runner:2.324.0-ubuntu-noble
+FROM myoung34/github-runner:2.327.1-ubuntu-noble
 
 # modify actions runner binaries to allow custom cache server implementation
 # https://gha-cache-server.falcondev.io/getting-started


### PR DESCRIPTION
This PR updates the runner image to the latest `2.327.1`