### PR TITLE
fix: bump to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM myoung34/github-runner:2.328.0-ubuntu-noble
+# FROM myoung34/github-runner:2.328.0-ubuntu-noble
+FROM myoung34/github-runner:ubuntu-noble
 
 # modify actions runner binaries to allow custom cache server implementation
 # https://gha-cache-server.falcondev.io/getting-started


### PR DESCRIPTION
Switching to non-pinned version to avoid this maintenance burden. I don't think we've had issues with these versions in the past, and we can always revert to the pinned version.