### PR TITLE
Add Application tags to GitHub runners infrastructure

### DIFF
--- a/cache-server/main.tf
+++ b/cache-server/main.tf
@@ -87,6 +87,11 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_write_policy" {
 
 resource "aws_ecs_cluster" "this" {
   name = local.name
+
+  tags = {
+    Application = "github-runners"
+    Service     = "ecs"
+  }
 }
 
 resource "aws_ecs_cluster_capacity_providers" "this" {
@@ -103,6 +108,11 @@ resource "aws_ecs_cluster_capacity_providers" "this" {
 resource "aws_cloudwatch_log_group" "this" {
   name              = "${local.name}-logs"
   retention_in_days = 1
+
+  tags = {
+    Application = "github-runners"
+    Service     = "cloudwatch"
+  }
 }
 
 resource "aws_ecs_task_definition" "this" {
@@ -230,6 +240,11 @@ resource "aws_iam_access_key" "this" {
 resource "aws_s3_bucket" "this" {
   bucket_prefix = "github-actions-cache"
   force_destroy = "true"
+
+  tags = {
+    Application = "github-runners"
+    Service     = "s3"
+  }
 }
 
 resource "aws_s3_bucket_policy" "this" {

--- a/runner/main.tf
+++ b/runner/main.tf
@@ -42,6 +42,11 @@ resource "aws_route" "nat_gateway" {
 resource "aws_ecr_repository" "this" {
   name         = local.name
   force_delete = true
+
+  tags = {
+    Application = "github-runners"
+    Service     = "ecr"
+  }
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -72,6 +77,11 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_write_policy" {
 
 resource "aws_ecs_cluster" "this" {
   name = local.name
+
+  tags = {
+    Application = "github-runners"
+    Service     = "ecs"
+  }
 }
 
 resource "aws_ecs_cluster_capacity_providers" "this" {
@@ -87,6 +97,11 @@ resource "aws_ecs_cluster_capacity_providers" "this" {
 resource "aws_cloudwatch_log_group" "this" {
   name              = "${local.name}-logs"
   retention_in_days = 1
+
+  tags = {
+    Application = "github-runners"
+    Service     = "cloudwatch"
+  }
 }
 
 resource "aws_ecs_task_definition" "this" {


### PR DESCRIPTION
## Summary

- Add cost allocation tags to ECS clusters, ECR repository, CloudWatch log groups, and S3 bucket
- Tags added: `Application: github-runners`, `Service: ecs/ecr/cloudwatch/s3`

## Impact

This addresses **~$100/month** in untagged GitHub runners costs in the Main account (898587786287).

## Changes

- `runner/main.tf`: Added tags to ECS cluster, ECR repository, CloudWatch log group
- `cache-server/main.tf`: Added tags to ECS cluster, CloudWatch log group, S3 bucket

## Test plan

- [ ] Terraform plan shows only tag additions
- [ ] Apply and verify tags appear in AWS Cost Explorer

🤖 Generated with [Claude Code](https://claude.ai/code)