### PR TITLE
feat: extending codeowners with Mario and Armin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @chris13524 @geekbrother @xdarksome
+* @chris13524 @geekbrother @xdarksome @mario-reown @arminx86-77616c


### PR DESCRIPTION
Extending CODEOWNERS with Mario `@mario-reown` and Armin `@arminx86-77616c`.