### PR TITLE
feat: compatible node version with playwright

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,0 @@
-# The Dockerfile has no COPY/ADD, so nothing here is needed in the build.
-# This only trims what buildx ships to the builder as context.
-.git
-.github
-**/target
-**/.terraform
-*.tfstate*
-webhook-runners
-*.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# The Dockerfile has no COPY/ADD, so nothing here is needed in the build.
+# This only trims what buildx ships to the builder as context.
+.git
+.github
+**/target
+**/.terraform
+*.tfstate*
+webhook-runners
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,25 @@ FROM myoung34/github-runner:2.337.0-ubuntu-noble
 # https://gha-cache-server.falcondev.io/getting-started
 RUN sed -i 's/\x41\x00\x43\x00\x54\x00\x49\x00\x4F\x00\x4E\x00\x53\x00\x5F\x00\x43\x00\x41\x00\x43\x00\x48\x00\x45\x00\x5F\x00\x55\x00\x52\x00\x4C\x00/\x41\x00\x43\x00\x54\x00\x49\x00\x4F\x00\x4E\x00\x53\x00\x5F\x00\x43\x00\x41\x00\x43\x00\x48\x00\x45\x00\x5F\x00\x4F\x00\x52\x00\x4C\x00/g' /actions-runner/bin/Runner.Worker.dll
 
+# Node 20+ is required: Playwright dropped Node 18 support in 1.62.0 (2026-07-24).
+# Ubuntu noble's apt `npm` pulls Node 18, so install Node from NodeSource instead.
+ARG NODE_MAJOR=22
+ARG PLAYWRIGHT_VERSION=1.62.1
+
 # Install Playwright System Dependencies
-RUN apt-get update && apt-get install -y npm
-RUN npm install -g playwright && playwright install-deps
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+       | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+       > /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends nodejs \
+  && npm install -g "playwright@${PLAYWRIGHT_VERSION}" \
+  && playwright install-deps \
+  && npm cache clean --force \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /root/.npm /tmp/*
 
 CMD timeout $TIMEOUT ./bin/Runner.Listener run --startuptype service


### PR DESCRIPTION
# Fix CI: Install Node 20+ so Playwright `install-deps` succeeds

## Problem

The Docker image build has been failing on every run since late July. Both Dependabot runner-version bumps failed at the same Docker step:

- **PR #39** — bump to `2.336.0` — CI run `30250576532` — failed on **2026-07-27**
- **PR #40** — bump to `2.337.0` — CI run `33381510728` — failed on **2026-08-31**

Both fail identically:

    #9 [4/4] RUN npm install -g playwright && playwright install-deps

    You are running Node.js 18.19.1.
    Playwright requires Node.js 20 or higher.

    ERROR: process "... playwright install-deps" did not complete successfully: exit code: 1

## Root Cause

The runner version bumps are **not** the cause of the failure. They only re-trigger this workflow via `on: push` with `paths: [Dockerfile]`.

The actual issue is a **Node.js / Playwright version incompatibility**:

- The Dockerfile installs Node.js through Ubuntu Noble's `apt` package, which provides **Node.js 18.19.1**.
- Playwright dropped Node.js 18 support in **`playwright@1.62.0`**, released on **2026-07-24**.
- The previous release, **`1.61.1`** (2026-06-23), still supported Node.js 18.
- Playwright is currently unpinned, so builds automatically started pulling `1.62.x`.
- `playwright install-deps` now exits when run under Node.js 18.

This matches the CI history exactly:

- The last green build was **2026-06-22** (PR #35), when the latest Playwright version was still `1.61.0`.
- The first failing build was **2026-07-27**, just three days after Playwright `1.62.0` was released.
- `2.336.0` never built successfully, so the last image actually published to ECR predates that version.

## Fix

This PR:

- Installs **Node.js 22 LTS** from NodeSource instead of Ubuntu's Node.js 18 package.
- Pins Playwright to **`1.62.1`** to prevent unexpected dependency drift from breaking future builds.

## Impact

Because the Docker image build currently fails, the publish step is skipped. As a result, `github-actions-runner:main` in ECR has not been updated.

Merging this PR will:

1. Unblock the Docker image build and publishing.
2. Allow the **`2.337.0`** runner version to finally be published.
3. Roll the updated runner out to the ECS Fargate runners used by:
   - `reown/rs-relay`
   - `walletConnect/web-monorepo`
