### PR TITLE
fix(ci): restrict GITHUB_TOKEN permissions in ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,14 @@ on:
       - "Dockerfile"
   workflow_dispatch:
 
+# Least privilege for GITHUB_TOKEN, applied to every job in this workflow.
+# `contents: read` is all that is needed: only the build job touches the repo
+# (actions/checkout). AWS auth uses static key secrets rather than OIDC, so no
+# `id-token: write`, and the artifact and type=gha cache steps authenticate with
+# ACTIONS_RUNTIME_TOKEN rather than GITHUB_TOKEN.
+permissions:
+  contents: read
+
 concurrency:
   # Support push/pr as event types with different behaviors each:
   # 1. push: queue up builds


### PR DESCRIPTION
Resolves both open [code-scanning alerts](https://github.com/WalletConnect/gh-actions-runners/security/code-scanning) — CodeQL's `actions/missing-workflow-permissions` on the `build` and `publish` jobs in `ci.yaml`. With no `permissions` block the jobs fall back to the repository default, which for repos created before February 2023 is read-write.

A root-level block covers both jobs, and `contents: read` is sufficient: only `build` touches the repo (via `actions/checkout`), AWS auth uses static key secrets rather than OIDC so no `id-token: write` is needed, and the artifact and `type=gha` cache steps authenticate with `ACTIONS_RUNTIME_TOKEN` rather than `GITHUB_TOKEN`. Verified with `actionlint` (clean) and by confirming both jobs inherit the block with all steps intact.

One thing I deliberately left alone: `setup-runners.yml` also has no `permissions` block, but CodeQL did not flag it and it is a `workflow_call` reusable workflow consumed by other repositories, where permissions are inherited from the caller. Constraining it could break those callers, so it seemed worth raising rather than changing unprompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)