### PR TITLE
ci: add rust build and test workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,55 @@
+name: rust
+
+on:
+  pull_request:
+    paths:
+      - "webhook-runners/**"
+      - ".github/workflows/rust.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "webhook-runners/**"
+      - ".github/workflows/rust.yml"
+  workflow_dispatch:
+
+# Least privilege for GITHUB_TOKEN: this workflow only reads the repo in order
+# to build and test. Nothing here publishes or writes back.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+defaults:
+  run:
+    working-directory: webhook-runners
+
+jobs:
+  check:
+    name: build & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Cache cargo build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: webhook-runners
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      # --locked makes cargo use Cargo.lock exactly as committed and fail if it
+      # is stale or inconsistent with Cargo.toml, so a dependency bump has to
+      # both resolve and compile before it can merge.
+      - name: Build
+        run: cargo build --locked --all-targets
+
+      - name: Test
+        run: cargo test --locked

--- a/webhook-runners/src/ecs.rs
+++ b/webhook-runners/src/ecs.rs
@@ -49,7 +49,12 @@ pub async fn spawn_runner(
         .cluster(cluster_arn)
         .task_definition(task_definition)
         .tags(Tag::builder().key("Repository").value(repository).build())
-        .tags(Tag::builder().key("Size").value(format!("{cpu}cpu-{memory}mem-{disk}disk-{timeout}")).build())
+        .tags(
+            Tag::builder()
+                .key("Size")
+                .value(format!("{cpu}cpu-{memory}mem-{disk}disk-{timeout}"))
+                .build(),
+        )
         .tags(Tag::builder().key("Job").value(job_url).build())
         .network_configuration(
             NetworkConfiguration::builder()

--- a/webhook-runners/src/main.rs
+++ b/webhook-runners/src/main.rs
@@ -89,13 +89,20 @@ mod jwt_backend_tests {
         let key = EncodingKey::from_rsa_pem(&pem).expect("from_rsa_pem");
         let token = encode(
             &Header::new(Algorithm::RS256),
-            &Claims { iss: "12345".into(), iat: 1_700_000_000, exp: 1_700_000_600 },
+            &Claims {
+                iss: "12345".into(),
+                iat: 1_700_000_000,
+                exp: 1_700_000_600,
+            },
             &key,
         )
         .expect("RS256 encode");
 
         assert_eq!(token.matches('.').count(), 2, "expected 3 JWT segments");
-        assert!(!token.split('.').nth(2).unwrap().is_empty(), "empty signature");
+        assert!(
+            !token.split('.').nth(2).unwrap().is_empty(),
+            "empty signature"
+        );
         println!("signed JWT ok, {} bytes", token.len());
     }
 }


### PR DESCRIPTION
No workflow in this repo ran on pull requests at all: `ci.yaml` triggers only on `push` to `main` with `paths: [Dockerfile]`, and `setup-runners.yml` is `workflow_call`. Even when `ci.yaml` does run it builds the self-hosted runner image, never the Rust crate — and `webhook-runners/main.tf` consumes a pre-built zip via `local_existing_package`, so the lambda was only ever compiled by hand on a developer machine. Dependency bumps were entirely unverified.

That is why #43 (`jsonwebtoken` 10 → 11) looked mergeable. It resolves cleanly and produces a valid lockfile, because cargo permits two semver-incompatible majors to coexist — but it does not compile: octocrab requires `jsonwebtoken ^10`, so `Octocrab::app()` takes a different `EncodingKey` type than the one `main.rs` passes (`E0308`).

This adds a `rust` workflow running fmt, build and test on `pull_request` and on push to `main`, filtered to `webhook-runners/**`. `--locked` makes cargo honor `Cargo.lock` as committed and fail if it is stale, so a bump has to both resolve *and* compile before it can merge. I verified it fails (exit 101) on the jsonwebtoken-11 branch and passes on `main`. #43 can stay open and simply fail this check.

Two notes on scope: it also runs `cargo fmt` over one pre-existing violation in `ecs.rs` and two in the test I added in #42, so the new fmt check starts green. clippy is deliberately excluded — there are ~12 pre-existing warnings, so `-D warnings` needs its own cleanup first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)